### PR TITLE
Removes logging statement and log import.

### DIFF
--- a/fako.go
+++ b/fako.go
@@ -85,7 +85,6 @@ var customGenerators = map[string]func() string{}
 //Fill fill all the fields that have a fako: tag
 func Fill(elems ...interface{}) {
 	for _, elem := range elems {
-		//log.Println(elem)
 		FillElem(elem)
 	}
 }

--- a/fako.go
+++ b/fako.go
@@ -86,7 +86,7 @@ var customGenerators = map[string]func() string{}
 //Fill fill all the fields that have a fako: tag
 func Fill(elems ...interface{}) {
 	for _, elem := range elems {
-		log.Println(elem)
+		//log.Println(elem)
 		FillElem(elem)
 	}
 }

--- a/fako.go
+++ b/fako.go
@@ -1,7 +1,6 @@
 package fako
 
 import (
-	"log"
 	"math/rand"
 	"reflect"
 	"time"


### PR DESCRIPTION
It spams the console when .Fill() is called repetitively. I'm assuming this was just accidentally left in during development.
